### PR TITLE
Allow all bucket if list of buckets not given

### DIFF
--- a/.github/testing/main.tf
+++ b/.github/testing/main.tf
@@ -62,7 +62,6 @@ module "r2-api-token_custom_name" {
 module "r2-api-token_wildcard" {
   source       = "../.."
   account_id   = var.account_id
-  allow_all_buckets = true
   bucket_write = false
   expires_on = timeadd(timestamp(), "10m")
 }

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,9 +10,10 @@ jobs:
     steps:
         - uses: actions/checkout@v4
 
-        - uses: actions/setup-go@v4
+        - uses: actions/setup-go@v5
           with:
             go-version: '1.20'
+            cache: false
         
         - uses: hashicorp/setup-terraform@v3
         

--- a/README.md
+++ b/README.md
@@ -42,10 +42,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Cloudflare Account ID | `string` | n/a | yes |
-| <a name="input_allow_all_buckets"></a> [allow\_all\_buckets](#input\_allow\_all\_buckets) | If true, grant access to all buckets | `bool` | `false` | no |
 | <a name="input_bucket_read"></a> [bucket\_read](#input\_bucket\_read) | If true, grant read access to the bucket(s) | `bool` | `true` | no |
 | <a name="input_bucket_write"></a> [bucket\_write](#input\_bucket\_write) | If true, grant write access to the bucket(s) | `bool` | `true` | no |
-| <a name="input_buckets"></a> [buckets](#input\_buckets) | List of R2 buckets to grant access to | `list(string)` | `[]` | no |
+| <a name="input_buckets"></a> [buckets](#input\_buckets) | List of R2 buckets to grant access to. If empty, all buckets will be granted access. | `list(string)` | `[]` | no |
 | <a name="input_condition_ip_in"></a> [condition\_ip\_in](#input\_condition\_ip\_in) | List of IP addresses or CIDR notation where the token may be used from. If not specified, the token will be valid for all IP addresses. | `list(string)` | `[]` | no |
 | <a name="input_condition_ip_not_in"></a> [condition\_ip\_not\_in](#input\_condition\_ip\_not\_in) | List of IP addresses or CIDR notation where the token should not be used from. | `list(string)` | `[]` | no |
 | <a name="input_expires_on"></a> [expires\_on](#input\_expires\_on) | The expiration time on or after which the token MUST NOT be accepted for processing. If not specified, the token will not expire. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ terraform {
 data "cloudflare_api_token_permission_groups" "this" {}
 
 locals {
-  resources          = var.allow_all_buckets ? { "com.cloudflare.edge.r2.bucket.*" = "*" } : { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_default_${bucket}" => "*" }
-  token_bucket_names = var.allow_all_buckets ? "All-Buckets" : join(",", var.buckets)
+  resources          = length(buckets) > 0 ? { "com.cloudflare.edge.r2.bucket.*" = "*" } : { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_default_${bucket}" => "*" }
+  token_bucket_names = length(buckets) ? "All-Buckets" : join(",", var.buckets)
 }
 
 resource "cloudflare_api_token" "token" {

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ terraform {
 data "cloudflare_api_token_permission_groups" "this" {}
 
 locals {
-  resources          = length(buckets) > 0 ? { "com.cloudflare.edge.r2.bucket.*" = "*" } : { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_default_${bucket}" => "*" }
-  token_bucket_names = length(buckets) ? "All-Buckets" : join(",", var.buckets)
+  resources          = length(var.buckets) > 0 ? { "com.cloudflare.edge.r2.bucket.*" = "*" } : { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_default_${bucket}" => "*" }
+  token_bucket_names = length(var.buckets) > 0 ? "All-Buckets" : join(",", var.buckets)
 }
 
 resource "cloudflare_api_token" "token" {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ terraform {
 data "cloudflare_api_token_permission_groups" "this" {}
 
 locals {
-  resources          = length(var.buckets) > 0 ? { "com.cloudflare.edge.r2.bucket.*" = "*" } : { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_default_${bucket}" => "*" }
+  resources          = length(var.buckets) > 0 ? { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_default_${bucket}" => "*" } : { "com.cloudflare.edge.r2.bucket.*" = "*" }
   token_bucket_names = length(var.buckets) > 0 ? "All-Buckets" : join(",", var.buckets)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,16 +10,9 @@ variable "token_name" {
 }
 
 variable "buckets" {
-  description = "List of R2 buckets to grant access to"
+  description = "List of R2 buckets to grant access to. If empty, all buckets will be granted access."
   type        = list(string)
   default     = []
-}
-
-variable "allow_all_buckets" {
-  description = "If true, grant access to all buckets"
-  type        = bool
-  default     = false
-
 }
 
 variable "bucket_read" {


### PR DESCRIPTION
Change behavior so that if `buckets` is not given, then all buckets will be allowed.