### PR TITLE
Added variable for setting jurisdiction of R2 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Cloudflare Account ID | `string` | n/a | yes |
+| <a name="input_jurisdiction"></a> [jurisdiction](#input\_jurisdiction) | Jurisdiction of R2 buckets | `string` | `default` | no |
 | <a name="input_bucket_read"></a> [bucket\_read](#input\_bucket\_read) | If true, grant read access to the bucket(s) | `bool` | `true` | no |
 | <a name="input_bucket_write"></a> [bucket\_write](#input\_bucket\_write) | If true, grant write access to the bucket(s) | `bool` | `true` | no |
 | <a name="input_buckets"></a> [buckets](#input\_buckets) | List of R2 buckets to grant access to. If empty, all buckets will be granted access. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ terraform {
 data "cloudflare_api_token_permission_groups" "this" {}
 
 locals {
-  resources          = length(var.buckets) > 0 ? { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_default_${bucket}" => "*" } : { "com.cloudflare.edge.r2.bucket.*" = "*" }
+  resources          = length(var.buckets) > 0 ? { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_${var.jurisdiction}_${bucket}" => "*" } : { "com.cloudflare.edge.r2.bucket.*" = "*" }
   token_bucket_names = length(var.buckets) > 0 ? join(",", var.buckets) : "All-Buckets"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "account_id" {
   type        = string
 }
 
+variable "jurisdiction" {
+  description = "Jurisdiction of R2 buckets"
+  type        = string
+  default     = "default"
+}
+
 variable "token_name" {
   description = "Name of the API token.\nIf none given then the fomart is: `R2-<comma separated names>-<Read if 'bucket-read'>-<Write if 'bucket-write'>`"
   type        = string


### PR DESCRIPTION
My buckets are in EU jurisdiction, and I've noticed your module doesn't have variable for that, so here's a quick fix

I could have configure validation rules for the new variable, but I was in a rush - hope that's not a problem!

https://developers.cloudflare.com/r2/api/s3/tokens/#create-api-tokens-via-api