### PR TITLE
Handle updated resources schema

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -25,7 +25,7 @@ output:
     ```
 
     ### Cloudflare provider version support
-
+    6.0 and above uses version 5.13 and above of the Cloudflare provider.
     5.0 and above uses version 5.0 of the Cloudflare provider.  
     4.1.1 and below uses version 4 of the Cloudflare provider.
 

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,17 +2,18 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "5.2.0"
-  constraints = ">= 5.0.0, < 6.0.0"
+  version     = "5.15.0"
+  constraints = ">= 5.13.0, < 6.0.0"
   hashes = [
-    "h1:JC86gRl0Hbavb0PTSI7z6K/h/BD5SYg14fyCVRu3Tp8=",
-    "h1:bBevLqDBPm9wGkuGlmpCNuyJVgCkgViL64Yn5ut4wRM=",
-    "zh:1c2785da1d01b2afd0cca625e8fee472a36f681dc206823db9d59e82a4a7db68",
-    "zh:cfe874ddc069cce594f2b660bbac4692bf267012002e1884fd0772ba3ddd77ef",
-    "zh:debe086c0fee03bebebce9bf387ff3859efb54471d10981fe408de81c1af03f1",
-    "zh:e42fa5538a90620a366af7a32a48197fcb4509c6ade5ad4750166435de06fbe3",
-    "zh:e8d6eef684bbd12c6d9678a8ebeb7be982eb44f5916e1c471419dd78d3911848",
-    "zh:ea0698597ccc8a5fef56d0b76678a20701dc4f8b74e4b4c53904e3372cb50de7",
+    "h1:EY8mWQO1NTqXuxnZxwVppF7AiLRdx7vRLYk6O7yzgPs=",
+    "zh:20a72bdbb28435f11d165b367732369e8f8163100a214e89ad720dae03fafa0c",
+    "zh:2eabd7a51fd7aafcab9861631d85c895914857e4fcd6fe2dd80bac22e74a1f47",
+    "zh:62828afbc1ba0e0a64bbb7d5d42ae3c2fbbaabb793010b07eba770ba91bae94f",
+    "zh:6693f1021e52c34a629300fbcd91f8bd4ca386fda3b45aec746b9c200c28a42c",
+    "zh:6873a15454b289e5baecc1d36ce8997266438761386a320753c63f13407f4a6b",
+    "zh:afbf4e56b3a5e5950b35b02b553313e4a2008415920b23f536682269c64ca549",
+    "zh:db367612900bc2e5a01c6a325e4cff9b1b04960ce9de3dd41671dda5a627ca1d",
+    "zh:eb7365eafc6160c3b304a9ce6a598e5400a2e779e9e2bd27976df244f79f774f",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ module "r2-api-token" {
 ```
 
 ### Cloudflare provider version support
-
+6.0 and above uses version 5.13 and above of the Cloudflare provider.
 5.0 and above uses version 5.0 of the Cloudflare provider.  
 4.1.1 and below uses version 4 of the Cloudflare provider.
 
@@ -27,13 +27,13 @@ I will continue to support the 4.1.1 version to the best of my ability, but I wi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 5, <6 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 5.13, <6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 5, <6 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 5.13, <6 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 5, <6"
+      version = ">= 5.13, <6"
     }
   }
 }
@@ -12,7 +12,7 @@ data "cloudflare_api_token_permission_groups_list" "this" {
 }
 
 locals {
-  resources          = length(var.buckets) > 0 ? { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_${var.jurisdiction}_${bucket}" => "*" } : { "com.cloudflare.edge.r2.bucket.*" = "*" }
+  resources          = jsonencode(length(var.buckets) > 0 ? { for bucket in var.buckets : "com.cloudflare.edge.r2.bucket.${var.account_id}_${var.jurisdiction}_${bucket}" => "*" } : { "com.cloudflare.edge.r2.bucket.*" = "*" })
   token_bucket_names = length(var.buckets) > 0 ? join(",", var.buckets) : "All-Buckets"
   r2_api_permissions = { for x in data.cloudflare_api_token_permission_groups_list.this.result : x.name => x.id if contains(["Workers R2 Storage Bucket Item Read", "Workers R2 Storage Bucket Item Write"], x.name) }
   permission_id_list = compact([


### PR DESCRIPTION
The Cloudflare Terraform provider made a breaking change when it comes to the resource schema a while back: https://github.com/cloudflare/terraform-provider-cloudflare/releases/tag/v5.13.0

This change updates the resources to use the same JSON encoding around the object.

I've not extensively tested this change using this module, I just figured you may want to know about it, since this module is one of the few examples of how to create tokens in a good way.